### PR TITLE
Rewrite sticker gesture handling

### DIFF
--- a/app/src/main/java/com/example/stickerdemo/MainActivity.kt
+++ b/app/src/main/java/com/example/stickerdemo/MainActivity.kt
@@ -4,32 +4,44 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTransformGestures
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.runtime.*
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.sp
-import androidx.compose.material3.Text
-import androidx.compose.ui.geometry.Offset
-import kotlin.math.max
-import kotlin.math.min
 import com.example.stickerdemo.ui.theme.StickerImageEditorTheme
+import kotlin.math.PI
+import kotlin.math.abs
+import kotlin.math.cos
+import kotlin.math.sin
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -37,87 +49,105 @@ class MainActivity : ComponentActivity() {
         setContent {
             StickerImageEditorTheme {
                 Surface(color = MaterialTheme.colorScheme.background) {
-                    StickerOnImageDemo()
+                    StickerEditorScreen()
                 }
             }
         }
     }
 }
 
-/**
- * 背景图上放一个可拖拽/缩放/旋转的贴纸
- */
 @Composable
-fun StickerOnImageDemo() {
-    // 容器（即图片显示区域）的像素尺寸
+private fun StickerEditorScreen() {
     var containerSize by remember { mutableStateOf(IntSize.Zero) }
+    var stickerSize by remember { mutableStateOf(IntSize.Zero) }
 
-    // 贴纸原始（未缩放前）像素尺寸
-    var stickerSizePx by remember { mutableStateOf(IntSize.Zero) }
-
-    // 贴纸状态：位移（相对容器左上角，单位像素）、缩放、旋转
-    var offset by remember { mutableStateOf(Offset.Zero) }
+    var stickerCenter by remember { mutableStateOf(Offset.Zero) }
     var scale by remember { mutableStateOf(1f) }
     var rotation by remember { mutableStateOf(0f) }
 
-    // 用一张示例图做背景（你可以换成自己的）
+    var hasInitialPlacement by remember { mutableStateOf(false) }
+
+    LaunchedEffect(containerSize) {
+        if (!hasInitialPlacement && containerSize != IntSize.Zero) {
+            stickerCenter = Offset(
+                x = containerSize.width / 2f,
+                y = containerSize.height / 2f
+            )
+            hasInitialPlacement = true
+        }
+    }
+
     Box(
         modifier = Modifier
             .fillMaxSize()
             .padding(16.dp),
         contentAlignment = Alignment.Center
     ) {
-        // 背景图外面再套个 Card，让边界清晰
         Card(
             modifier = Modifier
                 .fillMaxWidth()
-                .aspectRatio(1.6f) // 随便定个比例，实际可根据图片宽高比
+                .aspectRatio(1.6f)
                 .onGloballyPositioned { containerSize = it.size },
             shape = RoundedCornerShape(16.dp)
         ) {
-            Box {
+            Box(modifier = Modifier.background(Color(0xFF101010))) {
                 Image(
                     painter = painterResource(id = android.R.drawable.ic_menu_gallery),
                     contentDescription = null,
-                    modifier = Modifier.fillMaxSize(),
-                    contentScale = ContentScale.Crop
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize()
                 )
 
-                // —— 贴纸 —— //
                 Sticker(
-                    text = "可拖拽/缩放/旋转的贴纸",
                     modifier = Modifier
                         .align(Alignment.TopStart)
-                        // 我们用 graphicsLayer 的 translationX/Y 放到自定义 offset 位置
+                        .onGloballyPositioned { stickerSize = it.size }
                         .graphicsLayer {
-                            translationX = offset.x
-                            translationY = offset.y
+                            translationX = stickerCenter.x - stickerSize.width / 2f
+                            translationY = stickerCenter.y - stickerSize.height / 2f
                             scaleX = scale
                             scaleY = scale
                             rotationZ = rotation
-                        }
-                        // 测量贴纸“原始尺寸”，用于边界约束
-                        .onGloballyPositioned { stickerSizePx = it.size },
-                    onGesture = { pan, zoom, rotationChange ->
-                        // 1) 先处理选择（如果你有选择态的话，可在此标记）
-                        // 2) 再应用手势到状态（像素坐标系）
-                        val newScale = (scale * zoom).coerceIn(0.2f, 5f)
-                        val newRotation = (rotation + rotationChange)
+                            transformOrigin = TransformOrigin(0.5f, 0.5f)
+                        },
+                    text = "可拖拽/缩放/旋转的贴纸",
+                    onTransform = { pan, zoomChange, rotationChange, centroid ->
+                        if (stickerSize == IntSize.Zero || containerSize == IntSize.Zero) return@Sticker
 
-                        // 计算新的位移（像素）
-                        val newOffset = offset + pan
+                        val targetScale = (scale * zoomChange).coerceIn(MIN_SCALE, MAX_SCALE)
+                        val scaleFactor = if (scale == 0f) 1f else targetScale / scale
+                        val targetRotation = normalizeAngle(rotation + rotationChange)
 
-                        // 约束位移：保持贴纸“可视矩形”在容器内
-                        val clampedOffset = clampOffsetInsideContainer(
-                            candidate = newOffset,
-                            container = containerSize,
-                            stickerOriginal = stickerSizePx,
-                            scale = newScale
+                        val centroidBefore = localToContainer(
+                            local = centroid,
+                            center = stickerCenter,
+                            stickerSize = stickerSize,
+                            scale = scale,
+                            rotation = rotation
                         )
 
-                        offset = clampedOffset
-                        scale = newScale
-                        rotation = newRotation
+                        val centroidAfterPanOnly = localToContainer(
+                            local = centroid + pan,
+                            center = stickerCenter,
+                            stickerSize = stickerSize,
+                            scale = scale,
+                            rotation = rotation
+                        )
+
+                        val panGlobal = centroidAfterPanOnly - centroidBefore
+                        val centerVector = stickerCenter - centroidBefore
+                        val rotatedScaledVector = centerVector.rotate(rotationChange) * scaleFactor
+                        val newCenter = centroidBefore + panGlobal + rotatedScaledVector
+
+                        stickerCenter = clampCenterInsideContainer(
+                            candidate = newCenter,
+                            container = containerSize,
+                            stickerSize = stickerSize,
+                            scale = targetScale,
+                            rotation = targetRotation
+                        )
+                        scale = targetScale
+                        rotation = targetRotation
                     }
                 )
             }
@@ -125,82 +155,112 @@ fun StickerOnImageDemo() {
     }
 }
 
-/**
- * 一个简单的“文本贴纸”示例；你也可以换成图片贴纸或自绘内容。
- */
+private const val MIN_SCALE = 0.4f
+private const val MAX_SCALE = 4f
+
 @Composable
 private fun Sticker(
+    modifier: Modifier,
     text: String,
-    modifier: Modifier = Modifier,
-    onGesture: (pan: Offset, zoom: Float, rotationChange: Float) -> Unit
+    onTransform: (pan: Offset, zoom: Float, rotation: Float, centroid: Offset) -> Unit
 ) {
     Box(
         modifier = modifier
             .pointerInput(Unit) {
-                detectTransformGestures(
-                    onGesture = { _, pan, zoom, rotationChange ->
-                        // `pan` 即像素偏移；这里不需要任何比例换算
-                        onGesture(pan, zoom, rotationChange)
-                    }
-                )
+                detectTransformGestures { centroid, pan, zoom, rotation ->
+                    onTransform(pan, zoom, rotation, centroid)
+                }
             }
             .clip(RoundedCornerShape(12.dp))
-            .padding(4.dp)
+            .background(Color(0xAA000000))
+            .padding(horizontal = 16.dp, vertical = 12.dp)
     ) {
         Text(
             text = text,
-            modifier = Modifier
-                .padding(horizontal = 12.dp, vertical = 8.dp),
-            style = TextStyle(
-                color = Color.White,
-                fontSize = 18.sp,
-                fontWeight = FontWeight.Bold
-            )
-        )
-        // 简单铺一个半透明底，让贴纸更明显
-        Box(
-            Modifier
-                .matchParentSize()
-                .clip(RoundedCornerShape(12.dp))
-                .graphicsLayer { alpha = 0.25f }
-                .background(Color.Black)
+            color = Color.White,
+            fontSize = 18.sp,
+            fontWeight = FontWeight.Bold
         )
     }
 }
 
-/**
- * 把贴纸的“可视矩形”限制在容器内部：
- *  - 这里以贴纸的未旋转外接矩形做近似（旋转时可能会略出界，通常足够实用）。
- *  - 如需精确旋转后的 AABB，可在此根据 rotation 计算旋转矩形的包围盒后再约束。
- */
-private fun clampOffsetInsideContainer(
+private fun clampCenterInsideContainer(
     candidate: Offset,
     container: IntSize,
-    stickerOriginal: IntSize,
-    scale: Float
+    stickerSize: IntSize,
+    scale: Float,
+    rotation: Float
 ): Offset {
-    if (container == IntSize.Zero || stickerOriginal == IntSize.Zero) return candidate
+    if (container == IntSize.Zero || stickerSize == IntSize.Zero) return candidate
 
-    val stickerW = stickerOriginal.width * scale
-    val stickerH = stickerOriginal.height * scale
+    val halfExtents = calculateAabbHalfExtents(stickerSize, scale, rotation)
 
-    // 允许的范围：贴纸左上角 ∈ [0 .. container - sticker]
-    val minX = 0f
-    val minY = 0f
-    val maxX = container.width - stickerW
-    val maxY = container.height - stickerH
+    val minX = halfExtents.x
+    val maxX = container.width - halfExtents.x
+    val minY = halfExtents.y
+    val maxY = container.height - halfExtents.y
 
-    // 若贴纸比容器还大，则让其可在范围内自由拖动（上面的 max 可能为负）
-    val clampedX = clamp(candidate.x, minX.coerceAtMost(maxX), maxX.coerceAtLeast(minX))
-    val clampedY = clamp(candidate.y, minY.coerceAtMost(maxY), maxY.coerceAtLeast(minY))
+    val clampedX = if (minX > maxX) container.width / 2f else candidate.x.coerceIn(minX, maxX)
+    val clampedY = if (minY > maxY) container.height / 2f else candidate.y.coerceIn(minY, maxY)
 
     return Offset(clampedX, clampedY)
 }
 
-private fun clamp(v: Float, minV: Float, maxV: Float): Float =
-    max(minV, min(v, maxV))
+private fun calculateAabbHalfExtents(
+    stickerSize: IntSize,
+    scale: Float,
+    rotation: Float
+): Offset {
+    val scaledWidth = stickerSize.width * scale
+    val scaledHeight = stickerSize.height * scale
 
-// 给 Box.background 用
-private fun Modifier.background(color: Color) = this.then(
-    androidx.compose.ui.draw.drawBehind { drawRect(color) }
-)
+    val halfWidth = scaledWidth / 2f
+    val halfHeight = scaledHeight / 2f
+
+    val radians = rotation.toRadians()
+    val cosTheta = abs(cos(radians))
+    val sinTheta = abs(sin(radians))
+
+    val halfAabbWidth = halfWidth * cosTheta + halfHeight * sinTheta
+    val halfAabbHeight = halfWidth * sinTheta + halfHeight * cosTheta
+
+    return Offset(halfAabbWidth, halfAabbHeight)
+}
+
+private fun normalizeAngle(angle: Float): Float {
+    var normalized = angle % 360f
+    if (normalized < 0f) normalized += 360f
+    return normalized
+}
+
+private fun localToContainer(
+    local: Offset,
+    center: Offset,
+    stickerSize: IntSize,
+    scale: Float,
+    rotation: Float
+): Offset {
+    val localCenter = Offset(
+        x = stickerSize.width / 2f,
+        y = stickerSize.height / 2f
+    )
+    val relative = local - localCenter
+    val rotated = relative.rotate(rotation)
+    val scaled = rotated * scale
+    return center + scaled
+}
+
+private fun Offset.rotate(angle: Float): Offset {
+    if (angle == 0f) return this
+    val radians = angle.toRadians()
+    val cosTheta = cos(radians)
+    val sinTheta = sin(radians)
+    return Offset(
+        x = (x * cosTheta) - (y * sinTheta),
+        y = (x * sinTheta) + (y * cosTheta)
+    )
+}
+
+private operator fun Offset.times(value: Float): Offset = Offset(x * value, y * value)
+
+private fun Float.toRadians(): Float = (this / 180f) * PI.toFloat()


### PR DESCRIPTION
## Summary
- replace MainActivity with a cleaner sticker editor screen that tracks sticker center, scale, and rotation
- convert gesture centroid and pan values into container space so dragging, scaling, and rotation remain aligned with touch input
- clamp the sticker center using the rotated bounding box so movement stays within the background image

## Testing
- ./gradlew test --console=plain --no-daemon *(fails: SDK location not found in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca99bf71d88324a55f183687ee180e